### PR TITLE
Adds i2c bus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bmp280-core"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["qiuchengxuan <qiuchengxuan@gmail.com>"]
 edition = "2018"
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -108,12 +108,18 @@ pub enum I2cError<WE, RE> {
 
 pub struct I2cBus<I2C> {
     i2c: I2C,
-    addr: u8,
+    addr: I2cAddress,
+}
+
+#[derive(Copy, Clone)]
+pub enum I2cAddress {
+    SdoToGnd = 0x76,
+    SdoToInterfaceSupplyVoltage = 0x77,
 }
 
 impl<I2C> I2cBus<I2C> {
-    pub fn new(i2c: I2C) -> Self {
-        Self { i2c, addr: 0x76 }
+    pub fn new(i2c: I2C, addr: I2cAddress) -> Self {
+        Self { i2c, addr }
     }
 
     pub fn free(self) -> I2C {
@@ -128,20 +134,20 @@ where
     type Error = I2cError<WE, RE>;
 
     fn write(&mut self, reg: Register, value: u8) -> Result<(), Self::Error> {
-        let result = self.i2c.write(self.addr, &[reg as u8, value]);
+        let result = self.i2c.write(self.addr as u8, &[reg as u8, value]);
         result.map_err(|e| I2cError::WriteError(e))
     }
 
     fn read(&mut self, reg: Register) -> Result<u8, Self::Error> {
         let mut value = [0u8];
         self.i2c
-            .write_read(self.addr, &[reg as u8], &mut value)
+            .write_read(self.addr as u8, &[reg as u8], &mut value)
             .map_err(|e| I2cError::ReadError(e))?;
         Ok(value[0])
     }
 
     fn reads(&mut self, reg: Register, output: &mut [u8]) -> Result<(), Self::Error> {
-        self.i2c.write_read(self.addr, &[reg as u8], output).map_err(|e| I2cError::ReadError(e))?;
+        self.i2c.write_read(self.addr as u8, &[reg as u8], output).map_err(|e| I2cError::ReadError(e))?;
         Ok(())
     }
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -106,31 +106,28 @@ pub enum I2cError<WE, RE> {
     ReadError(RE),
 }
 
-pub struct I2cBus<I2C, D> {
+pub struct I2cBus<I2C> {
     i2c: I2C,
-    delay: D,
 }
 
-impl<I2C, D> I2cBus<I2C, D> {
-    pub fn new(i2c: I2C, delay: D) -> Self {
-        Self { i2c, delay }
+impl<I2C> I2cBus<I2C> {
+    pub fn new(i2c: I2C) -> Self {
+        Self { i2c }
     }
 
-    pub fn free(self) -> (I2C, D) {
-        (self.i2c, self.delay)
+    pub fn free(self) -> I2C {
+        return self.i2c;
     }
 }
 
-impl<I2C, D, WE, RE> Bus for I2cBus<I2C, D>
+impl<I2C, WE, RE> Bus for I2cBus<I2C>
 where
     I2C: i2c::Read<Error = RE> + i2c::Write<Error = WE>,
-    D: DelayUs<u8>,
 {
     type Error = I2cError<WE, RE>;
 
     fn write(&mut self, reg: Register, value: u8) -> Result<(), Self::Error> {
         let result = self.i2c.write(reg as u8, &[value]);
-        self.delay.delay_us(1);
         result.map_err(|e| I2cError::WriteError(e))
     }
 


### PR DESCRIPTION
I used `i2c::WriteRead` and `i2c::Write` traits from i2c. I could simplify it to just use `i2c::WriteRead` to also write with.

For `I2cBus::new` and `I2cBus::free` I didn't define the trail constraints as you did for the SpiBus. Being a rust newbie, I'm not really sure why you did that and it seems to work fine without so I left it out.

I have tested it on BMP280 using a raspberry pi pico. This seems to work as I am getting values back and not errors but still need to calculate the altitude from these to confirm it's OK.